### PR TITLE
Enable nested reply navigation

### DIFF
--- a/css/thread.css
+++ b/css/thread.css
@@ -194,6 +194,20 @@ body {
 .comment-like-btn i { color: #ef4444; margin-right: 6px; }
 .comment-reply-btn i { margin-right: 6px; }
 
+.replies-link {
+  margin-top: 8px;
+  font-size: 13px;
+}
+
+.replies-link a {
+  color: #3b82f6;
+  text-decoration: none;
+}
+
+.replies-link a:hover {
+  text-decoration: underline;
+}
+
 /* ---------------------------
    返信ページ（replies.html）
 --------------------------- */


### PR DESCRIPTION
## Summary
- show the number of child replies for each reply and add navigation to deeper levels
- aggregate per-comment reply counts when loading replies and filter out deleted entries
- style the replies link to match the thread view

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ce38127874832ba8c9f0f306cc6ace