### PR TITLE
Add Google AdSense placements for desktop and mobile

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -120,6 +120,60 @@ body {
     padding: 30px 0;
 }
 
+.page-with-ads {
+    display: flex;
+    justify-content: center;
+    align-items: flex-start;
+    gap: 24px;
+    max-width: 1400px;
+    margin: 0 auto;
+    padding: 0 20px;
+}
+
+.content-with-ads {
+    flex: 1 1 0;
+    min-width: 0;
+}
+
+.side-ad {
+    flex: 0 0 160px;
+    display: flex;
+    justify-content: center;
+}
+
+.side-ad .adsbygoogle {
+    display: block;
+    width: 160px;
+    min-height: 600px;
+}
+
+@media (max-width: 1200px) {
+    .page-with-ads {
+        gap: 16px;
+        padding: 0 12px;
+    }
+
+    .side-ad {
+        flex-basis: 120px;
+    }
+
+    .side-ad .adsbygoogle {
+        width: 120px;
+        min-height: 500px;
+    }
+}
+
+@media (max-width: 1024px) {
+    .page-with-ads {
+        flex-direction: column;
+        padding: 0 20px;
+    }
+
+    .side-ad {
+        display: none;
+    }
+}
+
 .loading {
     text-align: center;
     padding: 50px 20px;

--- a/css/thread.css
+++ b/css/thread.css
@@ -146,6 +146,24 @@ body {
   background: #fff;
 }
 
+.mobile-inline-ad {
+  border-top: 1px solid #e5e7eb;
+  padding: 16px 0;
+  display: none;
+  background: #fff;
+}
+
+.mobile-inline-ad .adsbygoogle {
+  display: block;
+  min-height: 250px;
+}
+
+@media (max-width: 1024px) {
+  .mobile-inline-ad {
+    display: block;
+  }
+}
+
 .comment-header {
   display: flex !important;
   flex-direction: row;

--- a/favorites.html
+++ b/favorites.html
@@ -15,6 +15,7 @@
     <link rel="stylesheet" href="css/style.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.4.0/css/all.min.css">
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5122489446866147" crossorigin="anonymous"></script>
 </head>
 <body>
     <header class="header">
@@ -41,7 +42,17 @@
     </header>
 
     <main class="main">
-        <div class="container">
+        <div class="page-with-ads">
+            <aside class="side-ad side-ad-left">
+                <ins class="adsbygoogle"
+                     style="display:block"
+                     data-ad-client="ca-pub-5122489446866147"
+                     data-ad-slot="0"
+                     data-ad-format="auto"
+                     data-full-width-responsive="false"></ins>
+            </aside>
+            <div class="content-with-ads">
+                <div class="container">
             <div class="page-header">
                 <h2><i class="fas fa-star"></i> お気に入り一覧</h2>
                 <p class="page-description">お気に入りに追加したスレッドの一覧です</p>
@@ -51,9 +62,20 @@
             <div class="threads-list" id="favoritesList">
                 <!-- お気に入り一覧がここに表示されます -->
             </div>
+                </div>
+            </div>
+            <aside class="side-ad side-ad-right">
+                <ins class="adsbygoogle"
+                     style="display:block"
+                     data-ad-client="ca-pub-5122489446866147"
+                     data-ad-slot="0"
+                     data-ad-format="auto"
+                     data-full-width-responsive="false"></ins>
+            </aside>
         </div>
     </main>
 
+    <script src="js/ads.js"></script>
     <script src="js/utils.js"></script>
     <script src="js/debug.js"></script>
     <script src="js/favorites.js"></script>

--- a/index.html
+++ b/index.html
@@ -52,6 +52,7 @@
     <link rel="stylesheet" href="css/style.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.4.0/css/all.min.css">
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5122489446866147" crossorigin="anonymous"></script>
 </head>
 <body>
     <header class="header">
@@ -151,7 +152,17 @@
     </section>
 
     <main class="main">
-        <div class="container">
+        <div class="page-with-ads">
+            <aside class="side-ad side-ad-left">
+                <ins class="adsbygoogle"
+                     style="display:block"
+                     data-ad-client="ca-pub-5122489446866147"
+                     data-ad-slot="0"
+                     data-ad-format="auto"
+                     data-full-width-responsive="false"></ins>
+            </aside>
+            <div class="content-with-ads">
+                <div class="container">
             <!-- 検索結果表示 -->
             <div class="search-results-info" id="searchResultsInfo" style="display: none;">
                 <span class="results-count"></span>
@@ -162,6 +173,16 @@
             <div class="threads-list" id="threadsList">
                 <!-- スレッド一覧がここに動的に表示されます -->
             </div>
+                </div>
+            </div>
+            <aside class="side-ad side-ad-right">
+                <ins class="adsbygoogle"
+                     style="display:block"
+                     data-ad-client="ca-pub-5122489446866147"
+                     data-ad-slot="0"
+                     data-ad-format="auto"
+                     data-full-width-responsive="false"></ins>
+            </aside>
         </div>
     </main>
 
@@ -293,6 +314,7 @@
         </div>
     </div>
 
+    <script src="js/ads.js"></script>
     <script src="js/utils.js"></script>
     <script src="js/debug.js"></script>
     <script src="js/reports.js"></script>

--- a/js/ads.js
+++ b/js/ads.js
@@ -1,0 +1,29 @@
+const ADSENSE_CLIENT_ID = 'ca-pub-5122489446866147';
+
+function pushGoogleAds() {
+  const adsArray = window.adsbygoogle || [];
+  window.adsbygoogle = adsArray;
+
+  const adElements = document.querySelectorAll('ins.adsbygoogle');
+  adElements.forEach((element) => {
+    if (!element.getAttribute('data-ad-client')) {
+      element.setAttribute('data-ad-client', ADSENSE_CLIENT_ID);
+    }
+
+    if (!element.getAttribute('data-adsbygoogle-status')) {
+      try {
+        adsArray.push({});
+      } catch (error) {
+        console.warn('AdSense push failed', error);
+      }
+    }
+  });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  pushGoogleAds();
+});
+
+document.addEventListener('ads:refresh', () => {
+  pushGoogleAds();
+});

--- a/js/thread.js
+++ b/js/thread.js
@@ -373,7 +373,17 @@ function displayComments(parents) {
   const list = document.getElementById('commentsList');
   if (!list) return;
 
-  list.innerHTML = parents.map(p => renderParentItem(p)).join('');
+  const fragments = [];
+  parents.forEach((parentComment, index) => {
+    fragments.push(renderParentItem(parentComment));
+
+    if ((index + 1) % 5 === 0) {
+      fragments.push(renderMobileInlineAd(index + 1));
+    }
+  });
+
+  list.innerHTML = fragments.join('');
+  document.dispatchEvent(new Event('ads:refresh'));
 }
 
 function renderParentItem(c) {
@@ -435,6 +445,19 @@ function renderParentItem(c) {
         </button>
       </div>
       ${repliesBlock}
+    </div>
+  `;
+}
+
+function renderMobileInlineAd(index) {
+  return `
+    <div class="mobile-inline-ad" data-inline-ad-index="${index}">
+      <ins class="adsbygoogle"
+           style="display:block"
+           data-ad-client="ca-pub-5122489446866147"
+           data-ad-slot="0"
+           data-ad-format="auto"
+           data-full-width-responsive="true"></ins>
     </div>
   `;
 }

--- a/myposts.html
+++ b/myposts.html
@@ -15,6 +15,7 @@
     <link rel="stylesheet" href="css/style.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.4.0/css/all.min.css">
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5122489446866147" crossorigin="anonymous"></script>
 </head>
 <body>
     <header class="header">
@@ -41,7 +42,17 @@
     </header>
 
     <main class="main">
-        <div class="container">
+        <div class="page-with-ads">
+            <aside class="side-ad side-ad-left">
+                <ins class="adsbygoogle"
+                     style="display:block"
+                     data-ad-client="ca-pub-5122489446866147"
+                     data-ad-slot="0"
+                     data-ad-format="auto"
+                     data-full-width-responsive="false"></ins>
+            </aside>
+            <div class="content-with-ads">
+                <div class="container">
             <div class="page-header">
                 <h2><i class="fas fa-user"></i> あなたの投稿一覧</h2>
                 <p class="page-description">あなたが作成したスレッドの一覧です</p>
@@ -51,9 +62,20 @@
             <div class="threads-list" id="myPostsList">
                 <!-- 投稿一覧がここに表示されます -->
             </div>
+                </div>
+            </div>
+            <aside class="side-ad side-ad-right">
+                <ins class="adsbygoogle"
+                     style="display:block"
+                     data-ad-client="ca-pub-5122489446866147"
+                     data-ad-slot="0"
+                     data-ad-format="auto"
+                     data-full-width-responsive="false"></ins>
+            </aside>
         </div>
     </main>
 
+    <script src="js/ads.js"></script>
     <script src="js/utils.js"></script>
     <script src="js/debug.js"></script>
     <script src="js/reports.js"></script>

--- a/replies.html
+++ b/replies.html
@@ -15,6 +15,7 @@
   <link rel="stylesheet" href="css/style.css">
   <link rel="stylesheet" href="css/thread.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.4.0/css/all.min.css">
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5122489446866147" crossorigin="anonymous"></script>
 </head>
 <body>
   <header class="header">
@@ -34,7 +35,17 @@
   </header>
 
   <main class="main">
-    <div class="container replies-container">
+    <div class="page-with-ads">
+      <aside class="side-ad side-ad-left">
+        <ins class="adsbygoogle"
+             style="display:block"
+             data-ad-client="ca-pub-5122489446866147"
+             data-ad-slot="0"
+             data-ad-format="auto"
+             data-full-width-responsive="false"></ins>
+      </aside>
+      <div class="content-with-ads">
+        <div class="container replies-container">
 
       <!-- 親コメント -->
       <section id="parentCommentSection">
@@ -78,6 +89,16 @@
           <button type="submit"><i class="fas fa-paper-plane"></i> 投稿する</button>
         </form>
       </section>
+        </div>
+      </div>
+      <aside class="side-ad side-ad-right">
+        <ins class="adsbygoogle"
+             style="display:block"
+             data-ad-client="ca-pub-5122489446866147"
+             data-ad-slot="0"
+             data-ad-format="auto"
+             data-full-width-responsive="false"></ins>
+      </aside>
     </div>
   </main>
 
@@ -89,6 +110,7 @@
     </div>
   </div>
 
+  <script src="js/ads.js"></script>
   <script src="js/utils.js"></script>
   <script src="js/reports.js"></script>
   <script src="js/replies.js"></script>

--- a/thread.html
+++ b/thread.html
@@ -16,6 +16,7 @@
     <link rel="stylesheet" href="css/thread.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.4.0/css/all.min.css">
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5122489446866147" crossorigin="anonymous"></script>
 </head>
 <body>
     <header class="header">
@@ -42,7 +43,17 @@
     </header>
 
     <main class="main">
-        <div class="container">
+        <div class="page-with-ads">
+            <aside class="side-ad side-ad-left">
+                <ins class="adsbygoogle"
+                     style="display:block"
+                     data-ad-client="ca-pub-5122489446866147"
+                     data-ad-slot="0"
+                     data-ad-format="auto"
+                     data-full-width-responsive="false"></ins>
+            </aside>
+            <div class="content-with-ads">
+                <div class="container">
             <!-- ヘッダー右側のアクション群 -->
             <div class="thread-header-bar">
               <button class="back-btn" onclick="history.back()">戻る</button>
@@ -131,6 +142,16 @@
                 </form>
               </section>
             </div>
+                </div>
+            </div>
+            <aside class="side-ad side-ad-right">
+                <ins class="adsbygoogle"
+                     style="display:block"
+                     data-ad-client="ca-pub-5122489446866147"
+                     data-ad-slot="0"
+                     data-ad-format="auto"
+                     data-full-width-responsive="false"></ins>
+            </aside>
         </div>
     </main>
 
@@ -142,6 +163,7 @@
         </div>
     </div>
 
+    <script src="js/ads.js"></script>
     <script src="js/utils.js"></script>
     <script src="js/debug.js"></script>
     <script src="js/reports.js"></script>


### PR DESCRIPTION
## Summary
- integrate Google AdSense script and desktop side-rail ad slots across the main HTML pages
- add responsive styles plus a helper script to initialize AdSense slots and render inline mobile ads every five comments in thread view
- ensure thread rendering injects mobile-only ad placeholders and refreshes AdSense after comment load

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ce492c8ba8832b82801fa3683d97a5