### PR TITLE
Add AdSense placements for desktop and mobile

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -120,6 +120,39 @@ body {
     padding: 30px 0;
 }
 
+/* サイド広告 */
+.side-ad {
+    position: fixed;
+    top: 140px;
+    width: 180px;
+    z-index: 20;
+    display: flex;
+    justify-content: center;
+}
+
+.side-ad-left {
+    left: clamp(16px, calc((100vw - 1000px) / 2 - 196px), 400px);
+}
+
+.side-ad-right {
+    right: clamp(16px, calc((100vw - 1000px) / 2 - 196px), 400px);
+}
+
+.side-ad-inner {
+    width: 100%;
+}
+
+.side-ad .adsbygoogle {
+    display: block !important;
+    width: 100% !important;
+}
+
+@media (max-width: 1440px) {
+    .side-ad {
+        display: none;
+    }
+}
+
 .loading {
     text-align: center;
     padding: 50px 20px;

--- a/css/thread.css
+++ b/css/thread.css
@@ -146,6 +146,23 @@ body {
   background: #fff;
 }
 
+.inline-ad-container {
+  display: none;
+  margin: 24px 0;
+  text-align: center;
+}
+
+.inline-ad-container .adsbygoogle {
+  display: block !important;
+  width: 100% !important;
+}
+
+@media (max-width: 767px) {
+  .inline-ad-container {
+    display: block;
+  }
+}
+
 .comment-header {
   display: flex !important;
   flex-direction: row;

--- a/favorites.html
+++ b/favorites.html
@@ -15,8 +15,9 @@
     <link rel="stylesheet" href="css/style.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.4.0/css/all.min.css">
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5122489446866147" crossorigin="anonymous"></script>
 </head>
-<body>
+<body data-adsense-slot-desktop-left="1234567890" data-adsense-slot-desktop-right="1234567891" data-adsense-slot-mobile-inline="1234567892">
     <header class="header">
         <div class="container">
             <div class="logo-container" onclick="window.location.href='/'">
@@ -55,6 +56,7 @@
     </main>
 
     <script src="js/utils.js"></script>
+    <script src="js/ads.js"></script>
     <script src="js/favorites.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -52,8 +52,9 @@
     <link rel="stylesheet" href="css/style.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.4.0/css/all.min.css">
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5122489446866147" crossorigin="anonymous"></script>
 </head>
-<body>
+<body data-adsense-slot-desktop-left="1234567890" data-adsense-slot-desktop-right="1234567891" data-adsense-slot-mobile-inline="1234567892">
     <header class="header">
         <div class="container">
             <div class="logo-container" onclick="window.location.href='/'">
@@ -294,6 +295,7 @@
     </div>
 
     <script src="js/utils.js"></script>
+    <script src="js/ads.js"></script>
     <script src="js/reports.js"></script>
     <script src="js/main.js"></script>
 </body>

--- a/js/ads.js
+++ b/js/ads.js
@@ -1,0 +1,96 @@
+(function() {
+  const ADSENSE_CLIENT_ID = 'ca-pub-5122489446866147';
+  const DEFAULT_SLOT_IDS = {
+    desktopLeft: '1234567890',
+    desktopRight: '1234567891',
+    mobileInline: '1234567892'
+  };
+
+  function getSlotId(name) {
+    const body = document.body;
+    if (!body) return DEFAULT_SLOT_IDS[name];
+    const datasetKey = `adsenseSlot${name.charAt(0).toUpperCase()}${name.slice(1)}`;
+    return body.dataset?.[datasetKey] || DEFAULT_SLOT_IDS[name];
+  }
+
+  function createSideAd(position) {
+    const slotKey = position === 'left' ? 'desktopLeft' : 'desktopRight';
+    const slotId = getSlotId(slotKey);
+    if (!slotId) return null;
+
+    const aside = document.createElement('aside');
+    aside.className = `side-ad side-ad-${position}`;
+
+    const inner = document.createElement('div');
+    inner.className = 'side-ad-inner';
+
+    const ins = document.createElement('ins');
+    ins.className = 'adsbygoogle';
+    ins.style.display = 'block';
+    ins.setAttribute('data-ad-client', ADSENSE_CLIENT_ID);
+    ins.setAttribute('data-ad-slot', slotId);
+    ins.setAttribute('data-ad-format', 'auto');
+    ins.setAttribute('data-full-width-responsive', 'true');
+
+    inner.appendChild(ins);
+    aside.appendChild(inner);
+
+    return aside;
+  }
+
+  function ensureSideAds() {
+    if (!document.body) return;
+
+    if (!document.querySelector('.side-ad.side-ad-left')) {
+      const left = createSideAd('left');
+      if (left) document.body.appendChild(left);
+    }
+
+    if (!document.querySelector('.side-ad.side-ad-right')) {
+      const right = createSideAd('right');
+      if (right) document.body.appendChild(right);
+    }
+  }
+
+  function requestAds(context = document) {
+    const ads = context.querySelectorAll('ins.adsbygoogle:not([data-adsense-loaded])');
+    ads.forEach(ad => {
+      ad.setAttribute('data-adsense-loaded', 'true');
+      (adsbygoogle = window.adsbygoogle || []).push({});
+    });
+  }
+
+  function renderInlineAdMarkup() {
+    const slotId = getSlotId('mobileInline');
+    if (!slotId) return '';
+
+    return `
+      <div class="inline-ad-container">
+        <ins class="adsbygoogle"
+             style="display:block"
+             data-ad-client="${ADSENSE_CLIENT_ID}"
+             data-ad-slot="${slotId}"
+             data-ad-format="auto"
+             data-full-width-responsive="true"></ins>
+      </div>
+    `;
+  }
+
+  function shouldShowInlineAds() {
+    if (window.matchMedia) {
+      return window.matchMedia('(max-width: 767px)').matches;
+    }
+    return window.innerWidth <= 767;
+  }
+
+  document.addEventListener('DOMContentLoaded', () => {
+    ensureSideAds();
+    requestAds();
+  });
+
+  window.adsenseHelpers = {
+    requestAds,
+    renderInlineAdMarkup,
+    shouldShowInlineAds
+  };
+})();

--- a/js/thread.js
+++ b/js/thread.js
@@ -389,11 +389,22 @@ function displayCommentsWithReplies(parents, hierarchy = new Map()) {
   if (!list) return;
 
   let html = '';
-  parents.forEach(parent => {
+  parents.forEach((parent, index) => {
     html += renderCommentWithReplies(parent, hierarchy, 0);
+
+    if (shouldInsertInlineAd(index + 1)) {
+      const inlineAd = renderInlineAdBlock();
+      if (inlineAd) {
+        html += inlineAd;
+      }
+    }
   });
-  
+
   list.innerHTML = html;
+
+  if (window.adsenseHelpers?.requestAds) {
+    window.adsenseHelpers.requestAds(list);
+  }
 }
 
 // 無限階層レンダリング（再帰）
@@ -483,6 +494,22 @@ function renderCommentWithReplies(comment, hierarchy, depth) {
   }
   
   return html;
+}
+
+function shouldInsertInlineAd(renderedCount) {
+  if (!window.adsenseHelpers?.shouldShowInlineAds) {
+    return false;
+  }
+
+  return renderedCount > 0 && renderedCount % 5 === 0 && window.adsenseHelpers.shouldShowInlineAds();
+}
+
+function renderInlineAdBlock() {
+  if (!window.adsenseHelpers?.renderInlineAdMarkup) {
+    return '';
+  }
+
+  return window.adsenseHelpers.renderInlineAdMarkup();
 }
 
 // 親コメントに対する「いいね」

--- a/myposts.html
+++ b/myposts.html
@@ -15,8 +15,9 @@
     <link rel="stylesheet" href="css/style.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.4.0/css/all.min.css">
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5122489446866147" crossorigin="anonymous"></script>
 </head>
-<body>
+<body data-adsense-slot-desktop-left="1234567890" data-adsense-slot-desktop-right="1234567891" data-adsense-slot-mobile-inline="1234567892">
     <header class="header">
         <div class="container">
             <div class="logo-container" onclick="window.location.href='/'">
@@ -55,6 +56,7 @@
     </main>
 
     <script src="js/utils.js"></script>
+    <script src="js/ads.js"></script>
     <script src="js/reports.js"></script>
     <script src="js/myposts.js" defer></script>
 

--- a/replies.html
+++ b/replies.html
@@ -15,8 +15,9 @@
   <link rel="stylesheet" href="css/style.css">
   <link rel="stylesheet" href="css/thread.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.4.0/css/all.min.css">
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5122489446866147" crossorigin="anonymous"></script>
 </head>
-<body>
+<body data-adsense-slot-desktop-left="1234567890" data-adsense-slot-desktop-right="1234567891" data-adsense-slot-mobile-inline="1234567892">
   <header class="header">
     <div class="container">
             <div class="logo-container" onclick="window.location.href='/'">
@@ -90,6 +91,7 @@
   </div>
 
   <script src="js/utils.js"></script>
+  <script src="js/ads.js"></script>
   <script src="js/reports.js"></script>
   <script src="js/replies.js"></script>
 </body>

--- a/thread.html
+++ b/thread.html
@@ -16,8 +16,9 @@
     <link rel="stylesheet" href="css/thread.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.4.0/css/all.min.css">
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5122489446866147" crossorigin="anonymous"></script>
 </head>
-<body>
+<body data-adsense-slot-desktop-left="1234567890" data-adsense-slot-desktop-right="1234567891" data-adsense-slot-mobile-inline="1234567892">
     <header class="header">
         <div class="container">
             <div class="logo-container" onclick="window.location.href='/'">
@@ -143,6 +144,7 @@
     </div>
 
     <script src="js/utils.js"></script>
+    <script src="js/ads.js"></script>
     <script src="js/reports.js"></script>
     <script src="js/thread.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- load the Google AdSense library across the main pages and tag the body with configurable slot ids for margin and inline units
- introduce a shared ads helper that injects side-rail ad containers on desktop and renders inline ad markup for mobile comment feeds
- style the new ad placements and insert an inline ad after every five comments on mobile thread views

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ce59b4f2b8832b854fc65e082c3892